### PR TITLE
Python build stages

### DIFF
--- a/python-multi-stage-builds/Dockerfile
+++ b/python-multi-stage-builds/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.8 AS development_build
+
+ARG DJANGO_ENV
+
+ENV DJANGO_ENV=${DJANGO_ENV} \
+  POETRY_VERSION=1.0.9 \
+  POETRY_VIRTUALENVS_CREATE=false \
+  POETRY_CACHE_DIR="/var/cache/pypoetry"
+
+RUN pip install "poetry==$POETRY_VERSION"
+
+WORKDIR /app
+COPY pyproject.toml poetry.lock /app/
+
+# Project initialization:
+RUN echo "$DJANGO_ENV" \
+  && poetry install \
+    $(if [ "$DJANGO_ENV" = "production" ]; then echo "--no-dev"; fi) \
+    --no-interaction --no-ansi
+
+FROM development_build AS production_build
+
+# Setting up proper permissions:
+RUN groupadd -g 999 appuser && useradd -d /app -r -u 999 -g appuser appuser \
+  && chown appuser:appuser -R /app
+
+# Running as non-root user:
+USER appuser
+
+# Setup codebase
+COPY --chown=appuser:appuser . /app

--- a/python-multi-stage-builds/docker-compose.yml
+++ b/python-multi-stage-builds/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.8"
+
+services:
+
+  api: &app
+    restart: always
+    env_file: .env
+    build:
+      context: .
+      target: development_build # Stops at the development_build stage as the source code is mounted below
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/code # Mounts source code for hot-reloading
+      - static:/static
+    secrets:
+      - google-cloud-key
+    environment:
+      - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/google-cloud-key
+    command: "sh ./services/api/startup.sh"
+ 
+ volumes:
+  static:
+  
+secrets:
+  google-cloud-key:
+    file: ~/.config/gcloud/application_default_credentials.json


### PR DESCRIPTION
Adds an example of using Docker and docker compose with multi-stage builds for development and prod, and using secrets, i.e. google application credentials for GCP.
